### PR TITLE
Answer:14 rxjs race condition

### DIFF
--- a/apps/rxjs-race-condition/src/app/app.component.ts
+++ b/apps/rxjs-race-condition/src/app/app.component.ts
@@ -1,11 +1,6 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  inject,
-  OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
-import { take } from 'rxjs';
+import { Observable, take } from 'rxjs';
 import { TopicModalComponent } from './topic-dialog.component';
 import { TopicService, TopicType } from './topic.service';
 
@@ -15,23 +10,20 @@ import { TopicService, TopicType } from './topic.service';
   template: ` <button (click)="openTopicModal()">Open Topic</button> `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class AppComponent implements OnInit {
+export class AppComponent {
   title = 'rxjs-race-condition';
   dialog = inject(MatDialog);
   topicService = inject(TopicService);
-  topics: TopicType[] = [];
+  topics$: Observable<TopicType[]>;
 
-  ngOnInit(): void {
-    this.topicService
-      .fakeGetHttpTopic()
-      .pipe(take(1))
-      .subscribe((topics) => (this.topics = topics));
+  constructor() {
+    this.topics$ = this.topicService.fakeGetHttpTopic().pipe(take(1));
   }
 
   openTopicModal() {
     this.dialog.open(TopicModalComponent, {
       data: {
-        topics: this.topics,
+        topics$: this.topics$,
       },
     });
   }

--- a/apps/rxjs-race-condition/src/app/topic-dialog.component.ts
+++ b/apps/rxjs-race-condition/src/app/topic-dialog.component.ts
@@ -1,4 +1,4 @@
-import { NgFor } from '@angular/common';
+import { CommonModule, NgFor } from '@angular/common';
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialogModule, MAT_DIALOG_DATA } from '@angular/material/dialog';
@@ -7,7 +7,7 @@ import { MatDialogModule, MAT_DIALOG_DATA } from '@angular/material/dialog';
   template: ` <h1 mat-dialog-title>Show all Topics</h1>
     <div mat-dialog-content>
       <ul>
-        <li *ngFor="let topic of data.topics">
+        <li *ngFor="let topic of data.topics$ | async">
           {{ topic }}
         </li>
       </ul>
@@ -15,7 +15,7 @@ import { MatDialogModule, MAT_DIALOG_DATA } from '@angular/material/dialog';
     <div mat-dialog-actions>
       <button mat-button mat-dialog-close>Close</button>
     </div>`,
-  imports: [MatDialogModule, MatButtonModule, NgFor],
+  imports: [CommonModule, MatDialogModule, MatButtonModule, NgFor],
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })


### PR DESCRIPTION
Observable is now subscribed to within the `TopicModalComponent` template instead of the AppComponent. This means the fetch only occurs on opening of the modal.

I decided to go with passing the observable through the `MAT_DIALOG_DATA`. An alternative would have been to just use the `TopicService` within the `TopicDialogComponent`. However that would involve a lot more code to allow it still be decoupled from the source. Although it's probably more flexible down the line.

## Checklist for challenge submission

- [x] Start your PR message with Answer:${challenge_number}
