### PR TITLE
fix(ngrx-1): reducers missing from config

### DIFF
--- a/apps/ngrx-1/README.md
+++ b/apps/ngrx-1/README.md
@@ -16,7 +16,7 @@ In NgRx, **selectors** is a very powerful tool often **misused**. You should use
 
 ##### You will have to
 
-1.  Refactor this working exemple of a dashboard of activities.
+1.  Refactor this working example of a dashboard of activities.
 
 ##### Rules:
 

--- a/apps/ngrx-1/src/app/app.config.ts
+++ b/apps/ngrx-1/src/app/app.config.ts
@@ -4,6 +4,21 @@ import { provideEffects } from '@ngrx/effects';
 import { ActivityEffects } from './store/activity/activity.effects';
 import { UserEffects } from './store/user/user.effects';
 import { StatusEffects } from './store/status/status.effects';
+import {
+  activityFeatureKey,
+  activityReducer,
+} from './store/activity/activity.reducer';
+
+import { statusFeatureKey, statusReducer } from './store/status/status.reducer';
+
+import { userFeatureKey, userReducer } from './store/user/user.reducer';
+
+const reducers = {
+  [statusFeatureKey]: statusReducer,
+  [activityFeatureKey]: activityReducer,
+  [userFeatureKey]: userReducer,
+};
+
 export const appConfig: ApplicationConfig = {
   providers: [
     provideStore(reducers),

--- a/apps/ngrx-1/src/main.ts
+++ b/apps/ngrx-1/src/main.ts
@@ -4,27 +4,10 @@ import { bootstrapApplication } from '@angular/platform-browser';
 
 import { AppComponent } from './app/app.component';
 
-import {
-  activityFeatureKey,
-  activityReducer,
-} from './app/store/activity/activity.reducer';
-
-import {
-  statusFeatureKey,
-  statusReducer,
-} from './app/store/status/status.reducer';
-
-import { userFeatureKey, userReducer } from './app/store/user/user.reducer';
 import { environment } from './environments/environment';
 
 if (environment.production) {
   enableProdMode();
 }
-
-const reducers = {
-  [statusFeatureKey]: statusReducer,
-  [activityFeatureKey]: activityReducer,
-  [userFeatureKey]: userReducer,
-};
 
 bootstrapApplication(AppComponent, appConfig);


### PR DESCRIPTION
_Not sure if you are accepting bug fixes_

Due to a recent refactor of upgrading to Angular v16, the reducers weren't copied over to the new `app.config.ts` file for the `ngrx-1` module.

Also fixed a minor spelling mistake in the related README.md file.
