### PR TITLE
Answer: 32 fix app not starting leveraging rxjs

### DIFF
--- a/apps/bug-cd/src/app/main-navigation.component.ts
+++ b/apps/bug-cd/src/app/main-navigation.component.ts
@@ -1,6 +1,7 @@
 import { AsyncPipe, NgFor, NgIf } from '@angular/common';
 import { Component, Input, inject } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
+import { map } from 'rxjs';
 import { FakeServiceService } from './fake.service';
 
 interface MenuItem {
@@ -34,31 +35,28 @@ interface MenuItem {
   },
 })
 export class NavigationComponent {
-  @Input() menus!: MenuItem[];
+  @Input({ required: true }) menus!: MenuItem[];
 }
 
 @Component({
   standalone: true,
   imports: [NavigationComponent, NgIf, AsyncPipe],
   template: `
-    <ng-container *ngIf="info$ | async as info">
-      <ng-container *ngIf="info !== null; else noInfo">
-        <app-nav [menus]="getMenu(info)" />
-      </ng-container>
+    <ng-container *ngIf="menu$ | async as menu">
+      <app-nav [menus]="menu" />
     </ng-container>
-
-    <ng-template #noInfo>
-      <app-nav [menus]="getMenu('')" />
-    </ng-template>
   `,
   host: {},
 })
 export class MainNavigationComponent {
   private fakeBackend = inject(FakeServiceService);
 
-  readonly info$ = this.fakeBackend.getInfoFromBackend();
+  readonly menu$ = this.fakeBackend
+    .getInfoFromBackend()
+    .pipe(map((info) => this.getMenu(info ? info : '')));
 
   getMenu(prop: string) {
+    console.log('Execute getMenu');
     return [
       { path: '/foo', name: `Foo ${prop}` },
       { path: '/bar', name: `Bar ${prop}` },


### PR DESCRIPTION
## Explanation

My assumption: The `getMenu(...)` method initially has been called directly within template so it was being executed on every Change Detection Cycle. Additionally in the example we didn't leveraged `ChangeDetectionStrategy.OnPush` which means every DOM events, timers, promises, XHR, observables etc caused new Change Detection Cycle run. It leaded to much unnecessary method executions affecting app performance and finally to infinite loop. 


Changes affect behaviour as the component requests for menu info once on menu$ variable is being initialised and `menu` reference not changes on every cd cycle.


