### PR TITLE
Answer:33

### DIFF
--- a/libs/decoupling/brain/src/index.ts
+++ b/libs/decoupling/brain/src/index.ts
@@ -1,4 +1,1 @@
-export {
-  BtnDisabledDirective,
-  ButtonState,
-} from './lib/button-disabled.directive';
+export { BtnDisabledDirective } from './lib/button-disabled.directive';

--- a/libs/decoupling/brain/src/lib/button-disabled.directive.ts
+++ b/libs/decoupling/brain/src/lib/button-disabled.directive.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @angular-eslint/directive-selector */
 /* eslint-disable @angular-eslint/no-host-metadata-property */
-import { Directive, WritableSignal, signal } from '@angular/core';
-
-export type ButtonState = 'enabled' | 'disabled';
+import { Directive, inject } from '@angular/core';
+import { BUTTON_STATE_SIGNAL_TOKEN } from '@angular-challenges/decoupling/core';
+import { ButtonStateService } from './button-state.service';
 
 @Directive({
   selector: 'button[btnDisabled]',
@@ -10,9 +10,16 @@ export type ButtonState = 'enabled' | 'disabled';
   host: {
     '(click)': 'toggleState()',
   },
+  providers: [
+    ButtonStateService,
+    {
+      provide: BUTTON_STATE_SIGNAL_TOKEN,
+      useFactory: () => inject(ButtonStateService).state,
+    },
+  ],
 })
 export class BtnDisabledDirective {
-  state: WritableSignal<ButtonState> = signal('enabled');
+  state = inject(ButtonStateService).state;
 
   toggleState() {
     this.state.set(this.state() === 'enabled' ? 'disabled' : 'enabled');

--- a/libs/decoupling/brain/src/lib/button-state.service.ts
+++ b/libs/decoupling/brain/src/lib/button-state.service.ts
@@ -1,0 +1,7 @@
+import { Injectable, signal } from '@angular/core';
+import { ButtonState } from '@angular-challenges/decoupling/core';
+
+@Injectable()
+export class ButtonStateService {
+  state = signal<ButtonState>('enabled');
+}

--- a/libs/decoupling/core/src/button-state-signal.token.ts
+++ b/libs/decoupling/core/src/button-state-signal.token.ts
@@ -1,0 +1,6 @@
+import { InjectionToken } from '@angular/core';
+import { ButtonStateSignal } from './button-state-signal';
+
+export const BUTTON_STATE_SIGNAL_TOKEN = new InjectionToken<ButtonStateSignal>(
+  'Signal for ButtonState'
+);

--- a/libs/decoupling/core/src/button-state-signal.ts
+++ b/libs/decoupling/core/src/button-state-signal.ts
@@ -1,0 +1,5 @@
+import { Signal } from '@angular/core';
+
+export type ButtonState = 'enabled' | 'disabled';
+
+export type ButtonStateSignal = Signal<ButtonState>;

--- a/libs/decoupling/core/src/index.ts
+++ b/libs/decoupling/core/src/index.ts
@@ -1,0 +1,2 @@
+export { ButtonState, ButtonStateSignal } from './button-state-signal';
+export { BUTTON_STATE_SIGNAL_TOKEN } from './button-state-signal.token';

--- a/libs/decoupling/helmet/src/lib/btn-style.directive.ts
+++ b/libs/decoupling/helmet/src/lib/btn-style.directive.ts
@@ -1,13 +1,12 @@
 /* eslint-disable @angular-eslint/directive-selector */
-import { BtnDisabledDirective } from '@angular-challenges/decoupling/brain';
 import {
   Directive,
-  ElementRef,
-  Renderer2,
   effect,
+  ElementRef,
   inject,
-  signal,
+  Renderer2,
 } from '@angular/core';
+import { BUTTON_STATE_SIGNAL_TOKEN } from '@angular-challenges/decoupling/core';
 
 @Directive({
   selector: 'button[hlm]',
@@ -18,16 +17,17 @@ import {
   },
 })
 export class BtnHelmetDirective {
-  btnState = inject(BtnDisabledDirective, { self: true });
-  public state = this.btnState?.state ?? signal('disabled').asReadonly();
+  state = inject(BUTTON_STATE_SIGNAL_TOKEN, { self: true });
   private renderer = inject(Renderer2);
   private element = inject(ElementRef);
 
-  private rendererEffect = effect(() => {
-    this.renderer.setAttribute(
-      this.element.nativeElement,
-      'data-state',
-      this.state()
-    );
-  });
+  constructor() {
+    effect(() => {
+      this.renderer.setAttribute(
+        this.element.nativeElement,
+        'data-state',
+        this.state()
+      );
+    });
+  }
 }


### PR DESCRIPTION
create an injection token representing a signal
for the button status.

In this solution the injection token is the signal itself. If it would be a service, the token wouldn't be necessary.

Since the directive needs access to a writable
signal, it needs to come up with an additional
hidden service, that contains the actual signal.

The injection token gets the signal from that
service and thus we can achieve a readonly signal.
