### PR TITLE
Answer:33: solution to challenge 33

### DIFF
--- a/libs/decoupling/brain/src/index.ts
+++ b/libs/decoupling/brain/src/index.ts
@@ -1,4 +1,1 @@
-export {
-  BtnDisabledDirective,
-  ButtonState,
-} from './lib/button-disabled.directive';
+export { BtnDisabledDirective } from './lib/button-disabled.directive';

--- a/libs/decoupling/brain/src/lib/button-disabled.directive.ts
+++ b/libs/decoupling/brain/src/lib/button-disabled.directive.ts
@@ -1,12 +1,20 @@
 /* eslint-disable @angular-eslint/directive-selector */
 /* eslint-disable @angular-eslint/no-host-metadata-property */
-import { Directive, WritableSignal, signal } from '@angular/core';
-
-export type ButtonState = 'enabled' | 'disabled';
+import {
+  BUTTON_STATE_TOKEN,
+  ButtonState,
+} from '@angular-challenges/decoupling/core';
+import { Directive, WritableSignal, forwardRef, signal } from '@angular/core';
 
 @Directive({
   selector: 'button[btnDisabled]',
   standalone: true,
+  providers: [
+    {
+      provide: BUTTON_STATE_TOKEN,
+      useExisting: forwardRef(() => BtnDisabledDirective),
+    },
+  ],
   host: {
     '(click)': 'toggleState()',
   },

--- a/libs/decoupling/core/src/index.ts
+++ b/libs/decoupling/core/src/index.ts
@@ -1,0 +1,5 @@
+export {
+  BUTTON_STATE_TOKEN,
+  ButtonState,
+  injectButtonState,
+} from './lib/btn-state';

--- a/libs/decoupling/core/src/lib/btn-state.ts
+++ b/libs/decoupling/core/src/lib/btn-state.ts
@@ -1,0 +1,13 @@
+import { inject, InjectionToken, InjectOptions, Signal } from '@angular/core';
+
+export type ButtonState = 'enabled' | 'disabled';
+
+export interface ButtonSignalState {
+  state: Signal<ButtonState>;
+}
+
+export const BUTTON_STATE_TOKEN: InjectionToken<ButtonSignalState> =
+  new InjectionToken<ButtonSignalState>('BUTTON_STATE_TOKEN');
+
+export const injectButtonState = (options: InjectOptions) =>
+  inject(BUTTON_STATE_TOKEN, options);

--- a/libs/decoupling/helmet/src/lib/btn-style.directive.ts
+++ b/libs/decoupling/helmet/src/lib/btn-style.directive.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @angular-eslint/directive-selector */
-import { BtnDisabledDirective } from '@angular-challenges/decoupling/brain';
+import { injectButtonState } from '@angular-challenges/decoupling/core';
 import {
   Directive,
   ElementRef,
@@ -18,7 +18,7 @@ import {
   },
 })
 export class BtnHelmetDirective {
-  btnState = inject(BtnDisabledDirective, { self: true });
+  btnState = injectButtonState({ self: true });
   public state = this.btnState?.state ?? signal('disabled').asReadonly();
   private renderer = inject(Renderer2);
   private element = inject(ElementRef);


### PR DESCRIPTION
use `forwardRef` to attach the instance of a component to a `InjectionToken` and then inject that `InjectionToken` somewhere else. This create highly decoupled components.
