### PR TITLE
fix: biglist seedrandom commonjs dependency

### DIFF
--- a/apps/performance/ngfor-biglist/project.json
+++ b/apps/performance/ngfor-biglist/project.json
@@ -20,7 +20,8 @@
           "apps/performance/ngfor-biglist/src/assets"
         ],
         "styles": ["apps/performance/ngfor-biglist/src/styles.scss"],
-        "scripts": []
+        "scripts": [],
+        "allowedCommonJsDependencies": ["seedrandom"]
       },
       "configurations": {
         "production": {


### PR DESCRIPTION
Suppress the warning in the console when you serve the app.  
