### PR TITLE
Answer:37 fix: improve performance of rendering huge list by using cdk virtual scroll

### DIFF
--- a/apps/performance/ngfor-biglist/src/app/person-list.component.ts
+++ b/apps/performance/ngfor-biglist/src/app/person-list.component.ts
@@ -3,25 +3,24 @@ import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 import { NgForTrackByModule } from '@angular-challenges/shared/directives';
 import { CommonModule } from '@angular/common';
 import { Person } from './person.model';
+import { ScrollingModule } from '@angular/cdk/scrolling';
 
 @Component({
   selector: 'app-person-list',
   standalone: true,
-  imports: [CommonModule, NgForTrackByModule],
+  imports: [CommonModule, ScrollingModule, NgForTrackByModule],
   template: `
-    <div class="h-[300px] relative overflow-hidden">
-      <div class="absolute inset-0 overflow-scroll">
-        <div
-          *ngFor="let person of persons; trackByProp: 'email'"
-          class="flex justify-between items-center border-b h-9">
-          <h3>{{ person.name }}</h3>
-          <p>{{ person.email }}</p>
-        </div>
+    <cdk-virtual-scroll-viewport itemSize="1" class="h-[300px]">
+      <div
+        *cdkVirtualFor="let person of persons; trackByProp: 'email'"
+        class="flex justify-between items-center border-b h-9">
+        <h3>{{ person.name }}</h3>
+        <p>{{ person.email }}</p>
       </div>
-    </div>
+    </cdk-virtual-scroll-viewport>
   `,
   host: {
-    class: 'w-full flex flex-col',
+    class: 'w-full flex flex-col ',
   },
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/libs/shared/directives/src/lib/track-by.directive.ts
+++ b/libs/shared/directives/src/lib/track-by.directive.ts
@@ -9,6 +9,7 @@ import {
   inject,
 } from '@angular/core';
 
+import { CdkVirtualForOf } from '@angular/cdk/scrolling';
 @Directive({
   selector: '[ngForTrackByProp]',
   standalone: true,
@@ -26,6 +27,23 @@ export class NgForTrackByPropDirective<T> {
 }
 
 @Directive({
+  selector: '[cdkVirtualForTrackByProp]',
+  standalone: true,
+})
+export class CdkVirtualForTrackByPropDirective<T> {
+  @Input() cdkVirtualForOf!: NgIterable<T>;
+
+  @Input()
+  set cdkVirtualForTrackByProp(cdkVirtualForTrackBy: keyof T) {
+    // setter
+    this.cdkVirtualFor.cdkVirtualForTrackBy = (index: number, item: T) =>
+      item[cdkVirtualForTrackBy];
+  }
+
+  private cdkVirtualFor = inject(CdkVirtualForOf<T>, { self: true });
+}
+
+@Directive({
   selector: '[ngForTrackById]',
   standalone: true,
 })
@@ -39,9 +57,28 @@ export class NgForTrackByIdDirective<T extends { id: string | number }> {
   }
 }
 
+@Directive({
+  selector: '[cdkVirtualForTrackById]',
+  standalone: true,
+})
+export class CdkVirtualForTrackByIdDirective<
+  T extends { id: string | number }
+> {
+  @Input() cdkVirtualForOf!: NgIterable<T>;
+
+  private cdkVirtualFor = inject(CdkVirtualForOf<T>, { self: true });
+
+  constructor() {
+    this.cdkVirtualFor.cdkVirtualForTrackBy = (index: number, item: T) =>
+      item.id;
+  }
+}
+
 export const NgForTrackByDirective: Provider[] = [
   NgForTrackByIdDirective,
   NgForTrackByPropDirective,
+  CdkVirtualForTrackByPropDirective,
+  CdkVirtualForTrackByIdDirective,
 ];
 
 @NgModule({


### PR DESCRIPTION
## Checklist for challenge submission

- [x] Start your PR message with Answer:${challenge_number}

What did I learn:
1. Signals - https://angular.io/guide/signals
2. The height of cdk-virtual-scroll-viewport element plays a big role in the performance of scrolling.  
3. templateCacheSize  and minBufferPx affects the amount of memory consumed, adjust them carefully.
4. *ngFor uses a separate [micro syntax](https://gist.github.com/mhevery/d3530294cff2e4a1b3fe15ff75d08855)