### PR TITLE
fix: add selectors for phone & video

### DIFF
--- a/apps/angular/injection-token/src/app/phone.component.ts
+++ b/apps/angular/injection-token/src/app/phone.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { TimerContainerComponent } from './timer-container.component';
 
 @Component({
+  selector: 'app-phone',
   standalone: true,
   imports: [TimerContainerComponent],
   template: `<div class="flex gap-2">

--- a/apps/angular/injection-token/src/app/video.component.ts
+++ b/apps/angular/injection-token/src/app/video.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { TimerContainerComponent } from './timer-container.component';
 
 @Component({
+  selector: 'app-video',
   standalone: true,
   imports: [TimerContainerComponent],
   template: `<div class="flex gap-2">


### PR DESCRIPTION
Without selectors, angular can't tell the components apart - name collision warning in console.  
