### PR TITLE
fix(doc): correct typos in documentation URLs for multiple apps

### DIFF
--- a/apps/angular/bug-cd/README.md
+++ b/apps/angular/bug-cd/README.md
@@ -10,4 +10,4 @@ npx nx serve angular-bug-cd
 
 ### Documentation and Instruction
 
-Challenge documentation is [here](https://angular-challenges.vercel.app/challenges/performance/32-angular-bug-cd/).
+Challenge documentation is [here](https://angular-challenges.vercel.app/challenges/performance/32-bug-cd/).

--- a/apps/angular/context-outlet-type/README.md
+++ b/apps/angular/context-outlet-type/README.md
@@ -10,4 +10,4 @@ npx nx serve angular-context-outlet-type
 
 ### Documentation and Instruction
 
-Challenge documentation is [here](https://angular-challenges.vercel.app/challenges/angular/4-angular-context-outlet-typed/).
+Challenge documentation is [here](https://angular-challenges.vercel.app/challenges/angular/4-context-outlet-typed/).

--- a/apps/angular/crud/README.md
+++ b/apps/angular/crud/README.md
@@ -10,4 +10,4 @@ npx nx serve angular-crud
 
 ### Documentation and Instruction
 
-Challenge documentation is [here](https://angular-challenges.vercel.app/challenges/angular/5-angular-crud/).
+Challenge documentation is [here](https://angular-challenges.vercel.app/challenges/angular/5-crud/).

--- a/apps/angular/decoupling/README.md
+++ b/apps/angular/decoupling/README.md
@@ -10,4 +10,4 @@ npx nx serve angular-decoupling
 
 ### Documentation and Instruction
 
-Challenge documentation is [here](https://angular-challenges.vercel.app/challenges/angular/33-angular-decoupling/).
+Challenge documentation is [here](https://angular-challenges.vercel.app/challenges/angular/33-decoupling/).

--- a/apps/angular/di/README.md
+++ b/apps/angular/di/README.md
@@ -10,4 +10,4 @@ npx nx serve angular-di
 
 ### Documentation and Instruction
 
-Challenge documentation is [here](https://angular-challenges.vercel.app/challenges/angular/16-angular-di/).
+Challenge documentation is [here](https://angular-challenges.vercel.app/challenges/angular/16-di/).

--- a/apps/angular/interop-rxjs-signal/README.md
+++ b/apps/angular/interop-rxjs-signal/README.md
@@ -10,4 +10,4 @@ npx nx serve angular-interop-rxjs-signal
 
 ### Documentation and Instruction
 
-Challenge documentation is [here](https://angular-challenges.vercel.app/challenges/angular/30-angular-interop-rxjs-signal/).
+Challenge documentation is [here](https://angular-challenges.vercel.app/challenges/angular/30-interop-rxjs-signal/).

--- a/apps/angular/module-to-standalone/README.md
+++ b/apps/angular/module-to-standalone/README.md
@@ -10,4 +10,4 @@ npx nx serve angular-module-to-standalone
 
 ### Documentation and Instruction
 
-Challenge documentation is [here](https://angular-challenges.vercel.app/challenges/angular/31-angular-module-to-standalone/).
+Challenge documentation is [here](https://angular-challenges.vercel.app/challenges/angular/31-module-to-standalone/).

--- a/apps/angular/permissions/README.md
+++ b/apps/angular/permissions/README.md
@@ -10,4 +10,4 @@ npx nx serve angular-permissions
 
 ### Documentation and Instruction
 
-Challenge documentation is [here](https://angular-challenges.vercel.app/challenges/angular/6-angular-permissions/).
+Challenge documentation is [here](https://angular-challenges.vercel.app/challenges/angular/6-permissions/).

--- a/apps/angular/projection/README.md
+++ b/apps/angular/projection/README.md
@@ -10,4 +10,4 @@ npx nx serve angular-projection
 
 ### Documentation and Instruction
 
-Challenge documentation is [here](https://angular-challenges.vercel.app/challenges/angular/1-angular-projection/).
+Challenge documentation is [here](https://angular-challenges.vercel.app/challenges/angular/1-projection/).

--- a/apps/angular/router-input/README.md
+++ b/apps/angular/router-input/README.md
@@ -10,4 +10,4 @@ npx nx serve angular-router-input
 
 ### Documentation and Instruction
 
-Challenge documentation is [here](https://angular-challenges.vercel.app/challenges/angular/22-angular-router-input/).
+Challenge documentation is [here](https://angular-challenges.vercel.app/challenges/angular/22-router-input/).

--- a/apps/angular/styling/README.md
+++ b/apps/angular/styling/README.md
@@ -10,4 +10,4 @@ npx nx serve angular-styling
 
 ### Documentation and Instruction
 
-Challenge documentation is [here](https://angular-challenges.vercel.app/challenges/angular/13-angular-styling/).
+Challenge documentation is [here](https://angular-challenges.vercel.app/challenges/angular/13-styling/).


### PR DESCRIPTION
## Fix Typos in URLs in README.md for Multiple Apps

- Corrected typos in URLs that were leading to 404 pages.
- This PR resolves the typos, redirecting users to the correct documentation page at (https://angular-challenges.vercel.app/).
