### PR TITLE
Answer:3 Directive Enhancement

### DIFF
--- a/apps/angular/ngfor-enhancement/src/app/app.component.ts
+++ b/apps/angular/ngfor-enhancement/src/app/app.component.ts
@@ -1,5 +1,6 @@
-import { NgFor, NgIf } from '@angular/common';
+import { NgIf } from '@angular/common';
 import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { NgForEmptyDirective } from './directives/ng-for-empty.directive';
 
 interface Person {
   name: string;
@@ -7,17 +8,14 @@ interface Person {
 
 @Component({
   standalone: true,
-  imports: [NgFor, NgIf],
   selector: 'app-root',
   template: `
-    <ng-container *ngIf="persons.length > 0; else emptyList">
-      <div *ngFor="let person of persons">
-        {{ person.name }}
-      </div>
-    </ng-container>
+    <div *ngFor="let person of persons; empty: emptyList">
+      {{ person.name }}
+    </div>
     <ng-template #emptyList>The list is empty !!</ng-template>
   `,
-  styles: [],
+  imports: [NgForEmptyDirective, NgIf],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AppComponent {

--- a/apps/angular/ngfor-enhancement/src/app/directives/ng-for-empty.directive.ts
+++ b/apps/angular/ngfor-enhancement/src/app/directives/ng-for-empty.directive.ts
@@ -1,0 +1,33 @@
+import { NgFor } from '@angular/common';
+import {
+  Directive,
+  Input,
+  OnChanges,
+  TemplateRef,
+  ViewContainerRef,
+  inject,
+} from '@angular/core';
+
+@Directive({
+  // eslint-disable-next-line @angular-eslint/directive-selector
+  selector: '[ngFor][ngForOf]',
+  standalone: true,
+  hostDirectives: [
+    {
+      directive: NgFor,
+      inputs: ['ngForOf', 'ngForTrackBy', 'ngForTemplate'],
+    },
+  ],
+})
+export class NgForEmptyDirective<T, U> implements OnChanges {
+  private viewContainer = inject(ViewContainerRef);
+
+  @Input() ngForOf!: T[];
+  @Input() ngForEmpty: TemplateRef<U> | undefined;
+
+  ngOnChanges(): void {
+    if (this.ngForOf.length === 0 && this.ngForEmpty) {
+      this.viewContainer.createEmbeddedView(this.ngForEmpty);
+    }
+  }
+}


### PR DESCRIPTION
## Checklist for challenge submission

- [x] Start your PR message with Answer:${challenge_number}

## Notes

My first attempt to solve this challenge was to extends NgFor (`export class NgForEmptyDirective<T, U> extends NgForOf`) and use directive composition to plug `NgIf`. And then I remember that extends is often a bad idea, I had to deal with many stuff from NgFor (inheritance hell).
On my second try, I swaped directives (NgFor in hostDirectives , and extends NgIf). Then I realized that ngIf is just a toggle on a viewContainer, so I can do it myself instead of extending the real directive.

I might be missing some cases here (such as dynamic swapping of the EmptyTemplate).
Performance should be ok, ngOnChanges is linked to Input properties and we can assume we won't have many reference changes in ngFor.

EDIT : Third challenge in a row 🎉 