### PR TITLE
Answer:4 Typed ContextOutlet

### DIFF
--- a/apps/angular/context-outlet-type/src/app/app.component.ts
+++ b/apps/angular/context-outlet-type/src/app/app.component.ts
@@ -15,9 +15,9 @@ import { PersonComponent, PersonTemplateDirective } from './person.component';
   selector: 'app-root',
   template: `
     <person [person]="person">
-      <ng-template personTemplate let-name let-age="age">
+      <ng-container *personTemplate="person; name as name; age as age">
         {{ name }}: {{ age }}
-      </ng-template>
+      </ng-container>
     </person>
 
     <list [list]="students">

--- a/apps/angular/context-outlet-type/src/app/app.component.ts
+++ b/apps/angular/context-outlet-type/src/app/app.component.ts
@@ -1,6 +1,6 @@
 import { NgTemplateOutlet } from '@angular/common';
 import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { ListComponent } from './list.component';
+import { ListComponent, ListItemTemplateDirective } from './list.component';
 import { PersonComponent, PersonTemplateDirective } from './person.component';
 
 @Component({
@@ -8,8 +8,9 @@ import { PersonComponent, PersonTemplateDirective } from './person.component';
   imports: [
     NgTemplateOutlet,
     PersonComponent,
-    ListComponent,
     PersonTemplateDirective,
+    ListComponent,
+    ListItemTemplateDirective,
   ],
   selector: 'app-root',
   template: `
@@ -20,15 +21,16 @@ import { PersonComponent, PersonTemplateDirective } from './person.component';
     </person>
 
     <list [list]="students">
-      <ng-template #listRef let-student let-i="index">
+      <ng-container
+        *listItemTemplate="students; listItem as student; index as i">
         {{ student.name }}: {{ student.age }} - {{ i }}
-      </ng-template>
+      </ng-container>
     </list>
 
     <list [list]="cities">
-      <ng-template #listRef let-city let-i="index">
+      <ng-container *listItemTemplate="cities; listItem as city; index as i">
         {{ city.name }}: {{ city.country }} - {{ i }}
-      </ng-template>
+      </ng-container>
     </list>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/apps/angular/context-outlet-type/src/app/app.component.ts
+++ b/apps/angular/context-outlet-type/src/app/app.component.ts
@@ -1,15 +1,20 @@
 import { NgTemplateOutlet } from '@angular/common';
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ListComponent } from './list.component';
-import { PersonComponent } from './person.component';
+import { PersonComponent, PersonTemplateDirective } from './person.component';
 
 @Component({
   standalone: true,
-  imports: [NgTemplateOutlet, PersonComponent, ListComponent],
+  imports: [
+    NgTemplateOutlet,
+    PersonComponent,
+    ListComponent,
+    PersonTemplateDirective,
+  ],
   selector: 'app-root',
   template: `
     <person [person]="person">
-      <ng-template #personRef let-name let-age="age">
+      <ng-template personTemplate let-name let-age="age">
         {{ name }}: {{ age }}
       </ng-template>
     </person>

--- a/apps/angular/context-outlet-type/src/app/list.component.ts
+++ b/apps/angular/context-outlet-type/src/app/list.component.ts
@@ -3,20 +3,42 @@ import {
   ChangeDetectionStrategy,
   Component,
   ContentChild,
+  Directive,
   Input,
   TemplateRef,
 } from '@angular/core';
 
+@Directive({
+  standalone: true,
+  selector: '[listItemTemplate]',
+})
+export class ListItemTemplateDirective<T> {
+  @Input() listItemTemplate!: T[];
+
+  static ngTemplateContextGuard<T>(
+    _directive: ListItemTemplateDirective<T>,
+    _context: unknown
+  ): _context is ListItemContext<T> {
+    return true;
+  }
+}
+
+interface ListItemContext<T> {
+  $implicit: T[];
+  listItem: T;
+  index: number;
+}
+
 @Component({
   selector: 'list',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, ListItemTemplateDirective],
   template: `
     <div *ngFor="let item of list; index as i">
       <ng-container
         *ngTemplateOutlet="
-          listTemplateRef || emptyRef;
-          context: { $implicit: item, appList: item, index: i }
+          listItemTemplateRef || emptyRef;
+          context: { $implicit: list, listItem: item, index: i }
         ">
       </ng-container>
     </div>
@@ -28,6 +50,6 @@ import {
 export class ListComponent<TItem extends object> {
   @Input() list!: TItem[];
 
-  @ContentChild('listRef', { read: TemplateRef })
-  listTemplateRef!: TemplateRef<unknown>;
+  @ContentChild(ListItemTemplateDirective, { read: TemplateRef })
+  listItemTemplateRef!: TemplateRef<ListItemContext<TItem>>;
 }

--- a/apps/angular/context-outlet-type/src/app/person.component.ts
+++ b/apps/angular/context-outlet-type/src/app/person.component.ts
@@ -17,6 +17,8 @@ interface Person {
   selector: '[personTemplate]',
 })
 export class PersonTemplateDirective {
+  @Input() personTemplate!: Person;
+
   static ngTemplateContextGuard(
     _directive: PersonTemplateDirective,
     _context: unknown
@@ -25,8 +27,10 @@ export class PersonTemplateDirective {
   }
 }
 
-class PersonContext {
-  constructor(public $implicit: string, public age: number) {}
+interface PersonContext {
+  $implicit: Person;
+  name: string;
+  age: number;
 }
 
 @Component({
@@ -37,7 +41,11 @@ class PersonContext {
     <ng-container
       *ngTemplateOutlet="
         personTemplateRef || emptyRef;
-        context: { $implicit: person.name, age: person.age }
+        context: {
+          $implicit: person,
+          name: person.name,
+          age: person.age
+        }
       "></ng-container>
 
     <ng-template #emptyRef> No Template </ng-template>
@@ -47,5 +55,5 @@ export class PersonComponent {
   @Input() person!: Person;
 
   @ContentChild(PersonTemplateDirective, { read: TemplateRef })
-  personTemplateRef: TemplateRef<PersonContext> | undefined;
+  personTemplateRef!: TemplateRef<PersonContext>;
 }

--- a/apps/angular/context-outlet-type/src/app/person.component.ts
+++ b/apps/angular/context-outlet-type/src/app/person.component.ts
@@ -1,9 +1,32 @@
 import { NgTemplateOutlet } from '@angular/common';
-import { Component, ContentChild, Input, TemplateRef } from '@angular/core';
+import {
+  Component,
+  ContentChild,
+  Directive,
+  Input,
+  TemplateRef,
+} from '@angular/core';
 
 interface Person {
   name: string;
   age: number;
+}
+
+@Directive({
+  standalone: true,
+  selector: '[personTemplate]',
+})
+export class PersonTemplateDirective {
+  static ngTemplateContextGuard(
+    _directive: PersonTemplateDirective,
+    _context: unknown
+  ): _context is PersonContext {
+    return true;
+  }
+}
+
+class PersonContext {
+  constructor(public $implicit: string, public age: number) {}
 }
 
 @Component({
@@ -23,6 +46,6 @@ interface Person {
 export class PersonComponent {
   @Input() person!: Person;
 
-  @ContentChild('#personRef', { read: TemplateRef })
-  personTemplateRef!: TemplateRef<unknown>;
+  @ContentChild(PersonTemplateDirective, { read: TemplateRef })
+  personTemplateRef: TemplateRef<PersonContext> | undefined;
 }


### PR DESCRIPTION
## Checklist for challenge submission

- [x] Start your PR message with Answer:${challenge_number}

## Notes

- ngTemplateContextGuard is not smart enough to infer generic without an input. Not sure why this is happening, but this make more sense when it comes to shorthand syntax.
- Thanks for the reminder on how to query a template variable with `@ContentChild("#myRef")`. I could have used it for challenge 1 instead of a dummy directive.
- Now I want to use this in real life.