### PR TITLE
fix: correct typo & grammar in test's name

### DIFF
--- a/apps/testing/harness/src/app/child.component.spec.ts
+++ b/apps/testing/harness/src/app/child.component.spec.ts
@@ -18,7 +18,7 @@ describe('ChildComponent', () => {
     });
   });
 
-  describe('When disabled chebkbox is toggle', () => {
+  describe('When disabled checkbox is toggled', () => {
     test('Then slider is disabled', async () => {
       await render(ChildComponent);
     });


### PR DESCRIPTION
## Fix typo

- There was a typo & grammar mistake in '**apps/testing/harness/src/app/child.component.spec.ts**' file.
- Changed '**When disabled chebkbox is toggle**' to '**When disabled checkbox is toggled**'.
