### PR TITLE
fix: note & reminder visible on light mode

### DIFF
--- a/docs/src/styles/custom-css.css
+++ b/docs/src/styles/custom-css.css
@@ -139,6 +139,11 @@ starlight-menu-button svg {
   color: var(--sl-color-text);
 }
 
+.starlight-aside--note .starlight-aside__title,
+.starlight-aside--tip .starlight-aside__title {
+  color: var(--sl-color-white);
+}
+
 .starlight-aside--danger {
   background-color: #f100002e;
   border: solid 1px red;

--- a/docs/src/styles/custom-css.css
+++ b/docs/src/styles/custom-css.css
@@ -139,11 +139,6 @@ starlight-menu-button svg {
   color: var(--sl-color-text);
 }
 
-.starlight-aside--note .starlight-aside__title,
-.starlight-aside--tip .starlight-aside__title {
-  color: white;
-}
-
 .starlight-aside--danger {
   background-color: #f100002e;
   border: solid 1px red;


### PR DESCRIPTION
Had trouble getting astro's preview command to work.

There was an typescript config strict error.  

The note and reminder are not visible on light mode.  I checked the preview seems like nothing else was broken deleting that css.  
