### PR TITLE
fix: missing dash in css variable 

### DIFF
--- a/docs/src/styles/custom-css.css
+++ b/docs/src/styles/custom-css.css
@@ -34,7 +34,7 @@
   border-radius: 6px;
   padding: 2px 8px;
   background-color: rgb(35, 134, 54);
-  color: var(-color-btn);
+  color: var(--color-btn);
 }
 
 .github-neutral-btn {


### PR DESCRIPTION
Github success btn is missing a dash.  

There are 2 other css problems.  

The sponsor button color in light mode and the color of reactions in dark mode.  Yet to solve either.  
