### PR TITLE
fix: angular material core theme added

### DIFF
--- a/apps/ngrx/notification/project.json
+++ b/apps/ngrx/notification/project.json
@@ -19,7 +19,10 @@
           "apps/ngrx/notification/src/favicon.ico",
           "apps/ngrx/notification/src/assets"
         ],
-        "styles": ["apps/ngrx/notification/src/styles.scss"],
+        "styles": [
+          "apps/ngrx/notification/src/styles.scss",
+          "./node_modules/@angular/material/prebuilt-themes/indigo-pink.css"
+        ],
         "scripts": [],
         "allowedCommonJsDependencies": ["seedrandom"]
       },


### PR DESCRIPTION
You need a core theme otherwise snackbar styling is off.  
