### PR TITLE
docs(projection): add related link reasons for avoiding magic strings

### DIFF
--- a/docs/src/content/docs/challenges/angular/1-projection.md
+++ b/docs/src/content/docs/challenges/angular/1-projection.md
@@ -40,4 +40,4 @@ While the application works, the developer experience is far from being optimal.
 
 - Try to work with the new built-in control flow syntax for loops and conditionals (documentation [here](https://angular.dev/guide/templates/control-flow))
 - Use the signal API to manage your components state (documentation [here](https://angular.dev/guide/signals))
-- To reference the template, use a directive instead of magic strings
+- To reference the template, use a directive instead of magic strings ([What is wrong with magic strings?](https://softwareengineering.stackexchange.com/a/365344))


### PR DESCRIPTION
Maybe it's good to know why we should use directives instead of magic strings to reference the template, so i added a interesting StackOverflow answer with reasons 🙂