### PR TITLE
Answer:47 Enum union

### DIFF
--- a/apps/typescript/enums-vs-union-types/src/app/app.component.ts
+++ b/apps/typescript/enums-vs-union-types/src/app/app.component.ts
@@ -94,9 +94,10 @@ export class AppComponent {
     }
   });
 
-  // either string or key seems to work
+  // either string or key works
+  // if not left / right / undefined -> error
   readonly directionLabel = computed<string>(() => {
-    const prefix = 'You choose to go';
+    const prefix = 'You chose to go';
     switch (this.direction()) {
       case 'left':
         return `${prefix} ${DirectionMap.left}`;

--- a/apps/typescript/enums-vs-union-types/src/app/app.component.ts
+++ b/apps/typescript/enums-vs-union-types/src/app/app.component.ts
@@ -15,14 +15,26 @@ const Difficulty = {
 
 type Difficulty = 'easy' | 'normal';
 
-type AllowedDirections = 'left' | 'right';
+//type AllowedDirections = 'left' | 'right';
 
-// dont think you need to declare yourself
+type Directions = {
+  left: string;
+  right: string;
+};
+
+/*
+// dont think you need to declare a MappedType yourself
+// the correct mapped type will be inferred automatically with Readonly
+// can add modifiers to MappedType -> `readonly`
+
+// Check this [YouTube Video](https://www.youtube.com/watch?v=fn12l_8LfxI)
+
 type MappedType = {
   [K in AllowedDirections]: string;
 };
+*/
 
-const DirectionMap: MappedType = {
+const DirectionMap: Readonly<Directions> = {
   left: 'left',
   right: 'right',
 };
@@ -71,7 +83,7 @@ const DirectionMap: MappedType = {
 export class AppComponent {
   readonly difficulty = signal<Difficulty>('easy');
 
-  readonly direction = signal<AllowedDirections | undefined>(undefined);
+  readonly direction = signal<keyof Directions | undefined>(undefined);
 
   readonly difficultyLabel = computed<string>(() => {
     switch (this.difficulty()) {
@@ -82,12 +94,13 @@ export class AppComponent {
     }
   });
 
+  // either string or key seems to work
   readonly directionLabel = computed<string>(() => {
     const prefix = 'You choose to go';
     switch (this.direction()) {
       case 'left':
         return `${prefix} ${DirectionMap.left}`;
-      case 'right':
+      case DirectionMap.right:
         return `${prefix} ${DirectionMap.right}`;
       default:
         return 'Choose a direction!';

--- a/apps/typescript/enums-vs-union-types/src/app/app.component.ts
+++ b/apps/typescript/enums-vs-union-types/src/app/app.component.ts
@@ -1,10 +1,5 @@
 import { Component, computed, signal } from '@angular/core';
 
-enum Difficulty {
-  EASY = 'easy',
-  NORMAL = 'normal',
-}
-
 enum Direction {
   LEFT = 'left',
   RIGHT = 'right',
@@ -23,6 +18,8 @@ const Difficulty = {
 // Object.values(enum) can be useful to spot differences between enums and const enums.  
 */
 
+type Difficulty = 'easy' | 'normal';
+
 @Component({
   standalone: true,
   imports: [],
@@ -30,10 +27,10 @@ const Difficulty = {
   template: `
     <section>
       <div>
-        <button mat-stroked-button (click)="difficulty.set(Difficulty.EASY)">
+        <button mat-stroked-button (click)="difficulty.set('easy')">
           Easy
         </button>
-        <button mat-stroked-button (click)="difficulty.set(Difficulty.NORMAL)">
+        <button mat-stroked-button (click)="difficulty.set('normal')">
           Normal
         </button>
       </div>
@@ -67,18 +64,17 @@ const Difficulty = {
   `,
 })
 export class AppComponent {
-  readonly Difficulty = Difficulty;
-  readonly difficulty = signal<Difficulty>(Difficulty.EASY);
+  readonly difficulty = signal<Difficulty>('easy');
 
   readonly Direction = Direction;
   readonly direction = signal<Direction | undefined>(undefined);
 
   readonly difficultyLabel = computed<string>(() => {
     switch (this.difficulty()) {
-      case Difficulty.EASY:
-        return Difficulty.EASY;
-      case Difficulty.NORMAL:
-        return Difficulty.NORMAL;
+      case 'easy':
+        return 'easy';
+      case 'normal':
+        return 'normal';
     }
   });
 

--- a/apps/typescript/enums-vs-union-types/src/app/app.component.ts
+++ b/apps/typescript/enums-vs-union-types/src/app/app.component.ts
@@ -1,13 +1,8 @@
 import { Component, computed, signal } from '@angular/core';
 
-enum Direction {
-  LEFT = 'left',
-  RIGHT = 'right',
-}
-
 /*
 // Using `as const` can be a great alternative to either.
-// You gain flexibility and consistency with such an implementation. 
+// You gain flexibility and consistency with such an implementation. Also, less complicated. 
 // [See this Matt Pocock video for more](https://www.youtube.com/watch?v=jjMbPt_H3RQ) 
 
 const Difficulty = {
@@ -19,6 +14,18 @@ const Difficulty = {
 */
 
 type Difficulty = 'easy' | 'normal';
+
+type AllowedDirections = 'left' | 'right';
+
+// dont think you need to declare yourself
+type MappedType = {
+  [K in AllowedDirections]: string;
+};
+
+const DirectionMap: MappedType = {
+  left: 'left',
+  right: 'right',
+};
 
 @Component({
   standalone: true,
@@ -39,10 +46,8 @@ type Difficulty = 'easy' | 'normal';
 
     <section>
       <div>
-        <button mat-stroked-button (click)="direction.set(Direction.LEFT)">
-          Left
-        </button>
-        <button mat-stroked-button (click)="direction.set(Direction.RIGHT)">
+        <button mat-stroked-button (click)="direction.set('left')">Left</button>
+        <button mat-stroked-button (click)="direction.set('right')">
           Right
         </button>
       </div>
@@ -66,8 +71,7 @@ type Difficulty = 'easy' | 'normal';
 export class AppComponent {
   readonly difficulty = signal<Difficulty>('easy');
 
-  readonly Direction = Direction;
-  readonly direction = signal<Direction | undefined>(undefined);
+  readonly direction = signal<AllowedDirections | undefined>(undefined);
 
   readonly difficultyLabel = computed<string>(() => {
     switch (this.difficulty()) {
@@ -81,10 +85,10 @@ export class AppComponent {
   readonly directionLabel = computed<string>(() => {
     const prefix = 'You choose to go';
     switch (this.direction()) {
-      case Direction.LEFT:
-        return `${prefix} ${Direction.LEFT}`;
-      case Direction.RIGHT:
-        return `${prefix} ${Direction.RIGHT}`;
+      case 'left':
+        return `${prefix} ${DirectionMap.left}`;
+      case 'right':
+        return `${prefix} ${DirectionMap.right}`;
       default:
         return 'Choose a direction!';
     }

--- a/apps/typescript/enums-vs-union-types/src/app/app.component.ts
+++ b/apps/typescript/enums-vs-union-types/src/app/app.component.ts
@@ -82,29 +82,20 @@ const DirectionMap: Readonly<Directions> = {
 })
 export class AppComponent {
   readonly difficulty = signal<Difficulty>('easy');
-
   readonly direction = signal<keyof Directions | undefined>(undefined);
 
   readonly difficultyLabel = computed<string>(() => {
-    switch (this.difficulty()) {
-      case 'easy':
-        return 'easy';
-      case 'normal':
-        return 'normal';
-    }
+    return this.difficulty() === 'easy' ? 'easy' : 'normal';
   });
 
-  // either string or key works
-  // if not left / right / undefined -> error
   readonly directionLabel = computed<string>(() => {
     const prefix = 'You chose to go';
-    switch (this.direction()) {
-      case 'left':
-        return `${prefix} ${DirectionMap.left}`;
-      case DirectionMap.right:
-        return `${prefix} ${DirectionMap.right}`;
-      default:
-        return 'Choose a direction!';
+    const selectedDirection = this.direction();
+
+    if (selectedDirection && DirectionMap[selectedDirection]) {
+      return `${prefix} ${DirectionMap[selectedDirection]}`;
+    } else {
+      return 'Choose a direction!';
     }
   });
 }

--- a/apps/typescript/enums-vs-union-types/src/app/app.component.ts
+++ b/apps/typescript/enums-vs-union-types/src/app/app.component.ts
@@ -10,6 +10,19 @@ enum Direction {
   RIGHT = 'right',
 }
 
+/*
+// Using `as const` can be a great alternative to either.
+// You gain flexibility and consistency with such an implementation. 
+// [See this Matt Pocock video for more](https://www.youtube.com/watch?v=jjMbPt_H3RQ) 
+
+const Difficulty = {
+  EASY: 'easy',
+  NORMAL: 'normal'
+} as const;
+
+// Object.values(enum) can be useful to spot differences between enums and const enums.  
+*/
+
 @Component({
   standalone: true,
   imports: [],
@@ -70,7 +83,7 @@ export class AppComponent {
   });
 
   readonly directionLabel = computed<string>(() => {
-    const prefix = 'You choosed to go';
+    const prefix = 'You choose to go';
     switch (this.direction()) {
       case Direction.LEFT:
         return `${prefix} ${Direction.LEFT}`;


### PR DESCRIPTION
Check my previous commits for the commented out implemenation I had.

I didn't implement here, but a POJO with `as const` would be another great replacement for an enum.   

I am not as comfortable using mapped types as the other methods.   Mapped Types require extra steps and the implementation here kind of eliminates some of that.  