### PR TITLE
fix(docs): missing projection challenge solution buttons

### DIFF
--- a/docs/src/content/docs/challenges/angular/1-projection.md
+++ b/docs/src/content/docs/challenges/angular/1-projection.md
@@ -8,6 +8,7 @@ contributors:
   - dmmishchenko
   - kabrunko-dev
   - svenson95
+challengeNumber: 1
 command: angular-projection
 blogLink: https://medium.com/@thomas.laforge/create-a-highly-customizable-component-cc3a9805e4c5
 videoLink:


### PR DESCRIPTION
I've noticed that in the first challenge "Projection" the solution buttons are not displayed (Community Solutions & Author's Solution). Close this PR if that's on purpose, if not, here's the fix to show them.