### PR TITLE
docs: faq note

### DIFF
--- a/docs/src/content/docs/guides/faq.md
+++ b/docs/src/content/docs/guides/faq.md
@@ -11,7 +11,7 @@ sidebar:
 <details>
   <summary>Why is my application not starting, or why do I encounter errors in my terminal when I run `nx serve`?</summary>
   
-  Most of the time, this issue arises because your node_modules are outdated, and you need to update them by running `npm ci`.
+  Most of the time, this issue arises because your node_modules are outdated, and you need to update them by running `npm ci`.  You might need to run `npm i` first if `npm ci` fails.
 
 If the installation process fails, you can resolve it by deleting your node_modules folder using the command `rm -rf node_modules` or `npx npkill` and then re-running `npm ci`.
 


### PR DESCRIPTION
Added a note about having to run install if `npm ci` fails.  I think there is a giscus comment about this.   If you run `npm ci` after a `git pull`, you will need to install first.  
