### PR TITLE
fix: latest challenge link 

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -13,7 +13,7 @@ hero:
       icon: right-arrow
       variant: primary
     - text: Go to the latest Challenge
-      link: /challenges/angular/50-bug-effect-signal/
+      link: /challenges/signal/50-bug-effect-signal/
       icon: rocket
     - text: Give a star
       link: https://github.com/tomalaforge/angular-challenges


### PR DESCRIPTION
Note: There are 2 `NEW` tags in the sidepanel.  When you merge challenge 51, you can fix that at the same time.  
