### PR TITLE
Answer:48

### DIFF
--- a/apps/forms/48-avoid-losing-form-data/src/app/app.routes.ts
+++ b/apps/forms/48-avoid-losing-form-data/src/app/app.routes.ts
@@ -1,4 +1,5 @@
 import { Route } from '@angular/router';
+import { canDeactivateGuard } from './core/can-deactivate.guard';
 import { JoinComponent } from './pages/join.component';
 import { PageComponent } from './pages/page.component';
 
@@ -11,6 +12,7 @@ export const appRoutes: Route[] = [
   {
     path: 'form',
     loadComponent: () => JoinComponent,
+    canDeactivate: [canDeactivateGuard],
   },
   {
     path: 'page-1',

--- a/apps/forms/48-avoid-losing-form-data/src/app/core/can-deactivate.guard.ts
+++ b/apps/forms/48-avoid-losing-form-data/src/app/core/can-deactivate.guard.ts
@@ -1,0 +1,18 @@
+import { CanDeactivateFn, UrlTree } from '@angular/router';
+import { Observable } from 'rxjs';
+
+export type CanDeactivateType =
+  | Observable<boolean | UrlTree>
+  | Promise<boolean | UrlTree>
+  | boolean
+  | UrlTree;
+
+export interface CanComponentDeactivate {
+  canDeactivate: () => CanDeactivateType;
+}
+
+export const canDeactivateGuard: CanDeactivateFn<CanComponentDeactivate> = (
+  component: CanComponentDeactivate,
+) => {
+  return component.canDeactivate ? component.canDeactivate() : true;
+};

--- a/apps/forms/48-avoid-losing-form-data/src/app/core/dialog.service.ts
+++ b/apps/forms/48-avoid-losing-form-data/src/app/core/dialog.service.ts
@@ -1,0 +1,20 @@
+import { Dialog, DialogConfig, DialogRef } from '@angular/cdk/dialog';
+import { BasePortalOutlet, ComponentType } from '@angular/cdk/portal';
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class DialogService {
+  private readonly dialog = inject(Dialog);
+
+  showDialog<T extends ComponentType<unknown>>(
+    component: T,
+    config: DialogConfig<T, DialogRef<unknown, unknown>, BasePortalOutlet>,
+  ) {
+    const dialogRef = this.dialog.open(component, config);
+
+    return dialogRef.closed as Observable<boolean>;
+  }
+}

--- a/apps/forms/48-avoid-losing-form-data/src/app/pages/join.component.ts
+++ b/apps/forms/48-avoid-losing-form-data/src/app/pages/join.component.ts
@@ -1,16 +1,83 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  viewChild,
+} from '@angular/core';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import {
+  CanComponentDeactivate,
+  CanDeactivateType,
+} from '../core/can-deactivate.guard';
 import { FormComponent } from '../ui/form.component';
 
 @Component({
   standalone: true,
-  imports: [FormComponent],
+  imports: [FormComponent, ReactiveFormsModule],
   template: `
     <section class="mx-auto	max-w-screen-sm">
       <div class="rounded-lg bg-white p-8 shadow-lg lg:p-12">
-        <app-form />
+        <app-form [formGroup]="form">
+          <div>
+            <label class="sr-only" for="name">Name</label>
+            <input
+              class="w-full rounded-lg border-gray-200 p-3 text-sm"
+              placeholder="Name"
+              type="text"
+              formControlName="name"
+              id="name" />
+          </div>
+
+          <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div>
+              <label class="sr-only" for="email">Email</label>
+              <input
+                class="w-full rounded-lg border-gray-200 p-3 text-sm"
+                placeholder="Email address"
+                type="email"
+                formControlName="email"
+                id="email" />
+            </div>
+
+            <div>
+              <label class="sr-only" for="phone">Phone</label>
+              <input
+                class="w-full rounded-lg border-gray-200 p-3 text-sm"
+                placeholder="Phone Number"
+                type="tel"
+                formControlName="phone"
+                id="phone" />
+            </div>
+          </div>
+
+          <div>
+            <label class="sr-only" for="message">Message</label>
+
+            <textarea
+              class="w-full rounded-lg border-gray-200 p-3 text-sm"
+              placeholder="Message"
+              rows="8"
+              formControlName="message"
+              id="message"></textarea>
+          </div>
+        </app-form>
       </div>
     </section>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class JoinComponent {}
+export class JoinComponent implements CanComponentDeactivate {
+  private readonly fb = inject(FormBuilder);
+  private readonly formComponent = viewChild(FormComponent);
+
+  protected form = this.fb.nonNullable.group({
+    name: ['', { validators: [Validators.required] }],
+    email: ['', [Validators.required, Validators.email]], // other syntax
+    phone: '',
+    message: '',
+  });
+
+  canDeactivate(): CanDeactivateType {
+    return this.formComponent()?.canDeactivate() ?? false;
+  }
+}

--- a/apps/forms/48-avoid-losing-form-data/src/app/ui/dialog.component.ts
+++ b/apps/forms/48-avoid-losing-form-data/src/app/ui/dialog.component.ts
@@ -1,4 +1,5 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { DialogRef } from '@angular/cdk/dialog';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 
 // NOTE : this is just the dialog content, you need to implement dialog logic
 
@@ -6,20 +7,24 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
   standalone: true,
   template: `
     <div role="alert" class="rounded-xl border border-gray-100 bg-white p-5">
-      <h3 class="block text-xl font-medium text-red-600">
+      <h3 id="dialog-title" class="block text-xl font-medium text-red-600">
         You have unsaved information!
       </h3>
 
-      <p class="mt-1 text-gray-700">Do you want to continue and lose them?</p>
+      <p id="dialog-content" class="mt-1 text-gray-700">
+        Do you want to continue and lose them?
+      </p>
 
       <div class="mt-4 flex gap-2">
         <button
-          class="inline-flex items-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-white hover:bg-red-700">
+          class="inline-flex items-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-white hover:bg-red-700"
+          (click)="dialogRef.close(true)">
           Yes continue
         </button>
 
         <button
-          class="block rounded-lg px-4 py-2 text-gray-700 transition hover:bg-gray-50">
+          class="block rounded-lg px-4 py-2 text-gray-700 transition hover:bg-gray-50"
+          (click)="dialogRef.close(false)">
           Stay on page
         </button>
       </div>
@@ -27,4 +32,6 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class AlertDialogComponent {}
+export class AlertDialogComponent {
+  protected readonly dialogRef = inject(DialogRef);
+}

--- a/apps/forms/48-avoid-losing-form-data/src/styles.scss
+++ b/apps/forms/48-avoid-losing-form-data/src/styles.scss
@@ -3,3 +3,4 @@
 @tailwind utilities;
 
 /* You can add global styles to this file, and also import other style files */
+@import '@angular/cdk/overlay-prebuilt.css';


### PR DESCRIPTION
- Convert dialog component to a dynamic form where each form group controls can be projected giving the flexibility to consumers to provide the desired form group.
- Implement browser native confirm dialog functionality when there are pending form changes.
- It would be really appreciated if someone can come up with a solution to hide/close the material dialog when the page tries to reload using the browser native button before the confirm popup is displayed. Currently, both material dialog and browser native popup are shown at the same time.
