### PR TITLE
Answer:36

### DIFF
--- a/apps/performance/36-ngfor-optimization/src/app/person-list.component.ts
+++ b/apps/performance/36-ngfor-optimization/src/app/person-list.component.ts
@@ -8,23 +8,23 @@ import { Person } from './person.model';
   standalone: true,
   imports: [CommonModule],
   template: `
-    <div
-      *ngFor="let person of persons"
-      class="flex items-center justify-between border-b">
-      <h3>{{ person.name }}</h3>
-      <div class="flex gap-10 py-1">
-        <button
-          class="rounded-md border bg-blue-500 p-2 text-white"
-          (click)="update.emit(person.email)">
-          UPDATE
-        </button>
-        <button
-          class="rounded-md border bg-red-500 p-2 text-white"
-          (click)="delete.emit(person.email)">
-          DELETE
-        </button>
+    @for (person of persons; track $index) {
+      <div class="flex items-center justify-between border-b">
+        <h3>{{ person.name }}</h3>
+        <div class="flex gap-10 py-1">
+          <button
+            class="rounded-md border bg-blue-500 p-2 text-white"
+            (click)="update.emit(person.email)">
+            UPDATE
+          </button>
+          <button
+            class="rounded-md border bg-red-500 p-2 text-white"
+            (click)="delete.emit(person.email)">
+            DELETE
+          </button>
+        </div>
       </div>
-    </div>
+    }
   `,
   host: {
     class: 'w-full flex flex-col',


### PR DESCRIPTION
- Using ngFor directive without trackBy function causes the whole DOM list of elements to be removed and recreated.
- The solution is to use the trackBy function alongside the directive. TrackBy is responsible for re-rendering only the list's object reference that has been changed. Using the Angular's 17 new ngFor syntax makes the presence of trackBy mandatory. 