### PR TITLE
Answer:53

### DIFF
--- a/apps/signal/53-big-signal-performance/src/app/address.component.ts
+++ b/apps/signal/53-big-signal-performance/src/app/address.component.ts
@@ -8,9 +8,9 @@ import { UserStore } from './user.service';
   template: `
     <div cd-flash class="m-4 block border border-gray-500 p-4">
       Address:
-      <div>Street: {{ userService.user().address.street }}</div>
-      <div>ZipCode: {{ userService.user().address.zipCode }}</div>
-      <div>City: {{ userService.user().address.city }}</div>
+      <div>Street: {{ userService.address().street }}</div>
+      <div>ZipCode: {{ userService.address().zipCode }}</div>
+      <div>City: {{ userService.address().city }}</div>
     </div>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/apps/signal/53-big-signal-performance/src/app/job.component.ts
+++ b/apps/signal/53-big-signal-performance/src/app/job.component.ts
@@ -8,8 +8,8 @@ import { UserStore } from './user.service';
   template: `
     <div cd-flash class="m-4 block border border-gray-500 p-4">
       Job:
-      <div>title: {{ userService.user().title }}</div>
-      <div>salary: {{ userService.user().salary }}</div>
+      <div>title: {{ userService.job().title }}</div>
+      <div>salary: {{ userService.job().salary }}</div>
     </div>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/apps/signal/53-big-signal-performance/src/app/name.component.ts
+++ b/apps/signal/53-big-signal-performance/src/app/name.component.ts
@@ -7,7 +7,7 @@ import { UserStore } from './user.service';
   standalone: true,
   template: `
     <div cd-flash class="m-4 block border border-gray-500 p-4">
-      Name: {{ userService.user().name }}
+      Name: {{ userService.name() }}
     </div>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/apps/signal/53-big-signal-performance/src/app/note.component.ts
+++ b/apps/signal/53-big-signal-performance/src/app/note.component.ts
@@ -7,7 +7,7 @@ import { UserStore } from './user.service';
   standalone: true,
   template: `
     <div cd-flash class="m-4 block border border-gray-500 p-4">
-      Note: {{ userService.user().note }}
+      Note: {{ userService.note() }}
     </div>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/apps/signal/53-big-signal-performance/src/app/user-form.component.ts
+++ b/apps/signal/53-big-signal-performance/src/app/user-form.component.ts
@@ -14,7 +14,7 @@ import { UserStore } from './user.service';
           class="rounded-md border border-gray-400"
           formControlName="name" />
       </div>
-      <div>
+      <div formGroupName="address">
         Address:
         <div>
           street:
@@ -41,17 +41,19 @@ import { UserStore } from './user.service';
           class="rounded-md border border-gray-400"
           formControlName="note" />
       </div>
-      <div>
-        title:
-        <input
-          class="rounded-md border border-gray-400"
-          formControlName="title" />
-      </div>
-      <div>
-        salary:
-        <input
-          class="rounded-md border border-gray-400"
-          formControlName="salary" />
+      <div formGroupName="job">
+        <div>
+          title:
+          <input
+            class="rounded-md border border-gray-400"
+            formControlName="title" />
+        </div>
+        <div>
+          salary:
+          <input
+            class="rounded-md border border-gray-400"
+            formControlName="salary" />
+        </div>
       </div>
       <button class="w-fit border p-2">Submit</button>
     </form>
@@ -64,37 +66,33 @@ import { UserStore } from './user.service';
 export class UserFormComponent {
   userStore = inject(UserStore);
 
-  form = new FormGroup({
-    name: new FormControl(this.userStore.user().name, { nonNullable: true }),
-    street: new FormControl(this.userStore.user().address.street, {
+  address = new FormGroup({
+    street: new FormControl(this.userStore.address().street, {
       nonNullable: true,
     }),
-    zipCode: new FormControl(this.userStore.user().address.zipCode, {
+    zipCode: new FormControl(this.userStore.address().zipCode, {
       nonNullable: true,
     }),
-    city: new FormControl(this.userStore.user().address.city, {
-      nonNullable: true,
-    }),
-    note: new FormControl(this.userStore.user().note, { nonNullable: true }),
-    title: new FormControl(this.userStore.user().title, { nonNullable: true }),
-    salary: new FormControl(this.userStore.user().salary, {
+    city: new FormControl(this.userStore.address().city, {
       nonNullable: true,
     }),
   });
 
+  job = new FormGroup({
+    title: new FormControl(this.userStore.job().title, { nonNullable: true }),
+    salary: new FormControl(this.userStore.job().salary, {
+      nonNullable: true,
+    }),
+  });
+
+  form = new FormGroup({
+    name: new FormControl(this.userStore.name(), { nonNullable: true }),
+    note: new FormControl(this.userStore.note(), { nonNullable: true }),
+    address: this.address,
+    job: this.job,
+  });
+
   submit() {
-    this.userStore.user.update((u) => ({
-      ...u,
-      name: this.form.getRawValue().name,
-      address: {
-        ...u.address,
-        street: this.form.getRawValue().street,
-        zipCode: this.form.getRawValue().zipCode,
-        city: this.form.getRawValue().city,
-      },
-      note: this.form.getRawValue().note,
-      title: this.form.getRawValue().title,
-      salary: this.form.getRawValue().salary,
-    }));
+    this.userStore.update(this.form.getRawValue());
   }
 }

--- a/apps/signal/53-big-signal-performance/src/app/user.service.ts
+++ b/apps/signal/53-big-signal-performance/src/app/user.service.ts
@@ -1,16 +1,57 @@
-import { Injectable, signal } from '@angular/core';
+import { computed } from '@angular/core';
+import {
+  patchState,
+  signalStore,
+  withComputed,
+  withMethods,
+  withState,
+} from '@ngrx/signals';
+import { deepEqual } from './utils';
 
-@Injectable({ providedIn: 'root' })
-export class UserStore {
-  user = signal({
-    name: 'Bob',
-    address: {
-      street: '',
-      zipCode: '',
-      city: '',
-    },
-    note: '',
+type AddressState = {
+  street: string;
+  zipCode: string;
+  city: string;
+};
+
+type JobState = {
+  title: string;
+  salary: number;
+};
+
+type UserState = {
+  name: string;
+  note: string;
+  address: AddressState;
+  job: JobState;
+};
+
+const initialState: UserState = {
+  name: 'Bob',
+  address: {
+    street: '',
+    zipCode: '',
+    city: '',
+  },
+  note: '',
+  job: {
     title: '',
     salary: 0,
-  });
-}
+  },
+};
+
+export const UserStore = signalStore(
+  { providedIn: 'root' },
+  withState(initialState),
+  withComputed((store) => ({
+    address: computed(() => store.address(), {
+      equal: (a, b) => deepEqual(a, b),
+    }),
+    job: computed(() => store.job(), { equal: (a, b) => deepEqual(a, b) }),
+  })),
+  withMethods((store) => ({
+    update(data: UserState): void {
+      patchState(store, data);
+    },
+  })),
+);

--- a/apps/signal/53-big-signal-performance/src/app/utils.ts
+++ b/apps/signal/53-big-signal-performance/src/app/utils.ts
@@ -1,0 +1,9 @@
+export function deepEqual<T extends Record<string, any>>(x: T, y: T): boolean {
+  const ok = Object.keys,
+    tx = typeof x,
+    ty = typeof y;
+  return x && y && tx === 'object' && tx === ty
+    ? ok(x).length === ok(y).length &&
+        ok(x).every((key) => deepEqual(x[key], y[key]))
+    : x === y;
+}

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@ngrx/effects": "18.0.0-beta.1",
     "@ngrx/entity": "18.0.0-beta.1",
     "@ngrx/router-store": "18.0.0-beta.1",
+    "@ngrx/signals": "^17.2.0",
     "@ngrx/store": "18.0.0-beta.1",
     "@nx/angular": "19.1.0",
     "@swc/helpers": "0.5.3",


### PR DESCRIPTION
Some thoughts on the challenge suggested solution provided:

- The reason why updating a single user property updates the entire application, is that a signal does not support a mutable data structure by default, unless a custom equality function is provided. In our case, we have a single signal containing an object(mutable) that is used in all components. `Object.is ` always returns false for the underlying mutable object and every component is re-rendered.
- Address and job related fields are grouped under their corresponding FormGroups. The idea behind this is not to introduce a signal(computed or not) for each user property to make fine-grained reactivity changes and trigger the change detection mechanism only for the components which contain updated user properties.
- Using name and note signals containing only primitive values, fixes the half portion of the problem. According to second point, I needed a way to trigger cd for address and job signals only when there is a change in their properties. Since, signals by default does not support mutable data, I provided a custom equality function that checks if the previous with the current signal version is deeply equal. If this is the case, and one of their property values have been changed the re-render is executed. In any other case, for example when we update the name or note field the re-render is not performed for address component because address signal previous and current version is equal.
