### PR TITLE
docs: checkout answer with codespace

### DIFF
--- a/docs/src/content/docs/guides/checkout-answer.md
+++ b/docs/src/content/docs/guides/checkout-answer.md
@@ -52,4 +52,6 @@ If the command doesn't work or fails, GitHub CLI will guide you through the proc
 
 🔥 You can now navigate through the solution locally and serve it to test it. 🔥
 
-<!-- gh repo set-default -->
+### Checkout with GitHub Codespaces
+
+You can checkout any **open** PR with GitHub Codespaces. After clicking the code button, you can navigate to the codespaces tab and click the green button to create a codespace on the PR's branch. After the codespace initializes, you can serve the app.


### PR DESCRIPTION
I didn't realize you could do this, but for any open PR, you can checkout the answer with GitHub Codespaces.  After any PR closes, you have to use the local method.  

I deleted a commented out command as well.  I don't know it is really necessary or not.    