### PR TITLE
fix: rename variable name "student" to "city" in addOne method in CityStore

### DIFF
--- a/apps/angular/1-projection/src/app/data-access/city.store.ts
+++ b/apps/angular/1-projection/src/app/data-access/city.store.ts
@@ -11,8 +11,8 @@ export class CityStore {
     this.cities.set(cities);
   }
 
-  addOne(student: City) {
-    this.cities.set([...this.cities(), student]);
+  addOne(city: City) {
+    this.cities.set([...this.cities(), city]);
   }
 
   deleteOne(id: number) {


### PR DESCRIPTION
Small changes in variable name in addOne method in CityStore. As per context the variable name Should be city instead of student.

## Checklist for challenge submission

- [ ] Start your PR message with Answer:${challenge_number}

## Warning:

- If you want feedback or review, you must support the project on GitHub:
  - [$5 per review](https://github.com/sponsors/tomalaforge)
  - [$25 for lifetime reviews](https://github.com/sponsors/tomalaforge)
  - Create one of more challenges
  - Have many valuable contributions to the project

Alternatively, you can still submit your PR to join the list of answered challenges or to be reviewed by a community member. 🔥
