### PR TITLE
docs(async-redirect): fix author tag

### DIFF
--- a/docs/src/content/docs/challenges/angular/60-async-redirect.md
+++ b/docs/src/content/docs/challenges/angular/60-async-redirect.md
@@ -1,7 +1,7 @@
 ---
 title: 🟢 async-redirect
 description: Challenge 60 is about using the new `redirectTo` function in Angular Router to modernize navigation logic.
-author: thomas laforge
+author: thomas-laforge
 contributors:
   - tomalaforge
 challengeNumber: 60


### PR DESCRIPTION
The author links were missing in the README.  And I noticed the hyphen was missing so I think this is the reason why. 
