### PR TITLE
fix(): replace broken ghs.vercel.app with GitHub GraphQL API endpoint for sponsors

### DIFF
--- a/docs/src/components/github/SponsorUser.svelte
+++ b/docs/src/components/github/SponsorUser.svelte
@@ -1,15 +1,13 @@
 <script>
   import { onMount } from 'svelte';
 
-
   let sponsors = [];
 
   onMount(async () => {
-    const sponsorFetch = await fetch('https://ghs.vercel.app/v2/sponsors/tomalaforge');
-    const data = await sponsorFetch.json();
-    sponsors = data.sponsors.current;
+    const response = await fetch('/api/sponsors');
+    const data = await response.json();
+    sponsors = data.sponsors ?? [];
   });
-
 </script>
 
 {#each sponsors as { username, avatar }}

--- a/docs/src/pages/api/sponsors.js
+++ b/docs/src/pages/api/sponsors.js
@@ -1,0 +1,74 @@
+export const prerender = false;
+
+const GITHUB_GRAPHQL_URL = 'https://api.github.com/graphql';
+
+const QUERY = `
+  query {
+    user(login: "tomalaforge") {
+      sponsorshipsAsMaintainer(activeOnly: true, first: 100) {
+        nodes {
+          sponsorEntity {
+            ... on User {
+              login
+              avatarUrl
+            }
+            ... on Organization {
+              login
+              avatarUrl
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+export async function GET() {
+  const { GITHUB_TOKEN } = import.meta.env;
+
+  if (!GITHUB_TOKEN) {
+    return new Response(JSON.stringify({ error: 'GITHUB_TOKEN not configured' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  try {
+    const response = await fetch(GITHUB_GRAPHQL_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${GITHUB_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ query: QUERY }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`GitHub API responded with ${response.status}`);
+    }
+
+    const { data, errors } = await response.json();
+
+    if (errors) {
+      throw new Error(errors[0].message);
+    }
+
+    const sponsors = data.user.sponsorshipsAsMaintainer.nodes.map((node) => ({
+      username: node.sponsorEntity.login,
+      avatar: node.sponsorEntity.avatarUrl,
+    }));
+
+    return new Response(JSON.stringify({ sponsors }), {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'public, max-age=3600',
+      },
+    });
+  } catch (err) {
+    return new Response(JSON.stringify({ error: err.message }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+}


### PR DESCRIPTION
Replace the broken third-party `ghs.vercel.app` sponsors API with a self-hosted serverless endpoint at `/api/sponsors` that queries GitHub's GraphQL API (`sponsorshipsAsMaintainer`) directly. The `GITHUB_TOKEN` env var (a PAT for `tomalaforge`) must be set in Vercel project settings. `SponsorUser.svelte` now fetches from `/api/sponsors` instead of the defunct external service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a site API endpoint that retrieves active maintainer sponsorships and displays sponsor names and avatars.
  * Sponsor information is now loaded through the site’s own endpoint for more consistent availability.
* **Bug Fixes**
  * Improved handling when sponsorship data is unavailable, ensuring the sponsor section falls back gracefully.
  * Added clearer error responses for configuration, connection, and data retrieval failures.
* **Performance**
  * Enabled public caching of successful sponsorship responses for up to one hour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->