### PR TITLE
chore(): update Node.js engine to >=24.0.0 for Vercel

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "postinstall": "playwright install chromium"
   },
   "engines": {
-    "node": ">=20.19.6"
+    "node": ">=24.0.0"
   },
   "private": true,
   "packageManager": "pnpm@10.23.0",


### PR DESCRIPTION
✅ Challenge Submission Checklist

Start your PR title with: Answer:${challenge_number}

⚠️ Important Notice

If you would like personal feedback or a detailed review, please support the project on GitHub:

- $5 — Review per PR
- $30 — Lifetime access to reviews and Q&A
- $100 — Lifetime access to reviews and Q&A + a 45-minute video call
  👉 https://github.com/sponsors/tomalaforge

You can also submit a PR without sponsorship to:

- Be listed among the answered challenges, or
- Receive a review from a community member. 🔥

---

Updates the `engines.node` field in `package.json` from `>=20.19.6` to `>=24.0.0` to resolve the Vercel deprecation warning for Node.js 20.x, which will cause build failures after 2026-10-01.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the minimum supported Node.js version to 24.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->