### PR TITLE
fix(website): widen giscus comments and rename CLI step

### DIFF
--- a/website/src/app/pages/docs/doc-page.html
+++ b/website/src/app/pages/docs/doc-page.html
@@ -1,5 +1,6 @@
 <div class="flex gap-10 px-4 py-8 sm:px-6 lg:px-10">
-  <article class="min-w-0 max-w-3xl flex-1">
+  <article class="min-w-0 flex-1">
+    <div class="max-w-3xl">
     @if (doc().collection === 'challenges' && doc().challengeNumber) {
       <header
         class="relative mb-10 overflow-hidden rounded-2xl border border-neutral-200 bg-gradient-to-br from-neutral-100 via-white to-white p-6 sm:p-8 dark:border-neutral-800 dark:from-neutral-900 dark:via-neutral-950 dark:to-neutral-950">
@@ -140,6 +141,8 @@
         </div>
       </footer>
     }
+
+    </div>
 
     @if (!doc().noComments) {
       <app-comments [term]="doc().title + ' | Angular Challenges'" />

--- a/website/src/app/pages/docs/try-challenge.html
+++ b/website/src/app/pages/docs/try-challenge.html
@@ -42,10 +42,10 @@
         </button>
       </div>
 
-      <!-- 1. One command -->
+      <!-- 1. Angular challenge CLI -->
       <section class="mb-9">
         <h3 class="mb-3 text-lg font-semibold text-neutral-900 dark:text-white">
-          <span class="mr-1.5 text-pink-500">1.</span> One command
+          <span class="mr-1.5 text-pink-500">1.</span> Angular challenge CLI
           <span
             class="ml-1.5 rounded bg-pink-600/10 px-2 py-0.5 align-middle text-xs font-medium text-pink-600 dark:text-pink-400"
             >recommended</span


### PR DESCRIPTION
## Summary

- Move `max-w-3xl` from the `<article>` element to an inner wrapper `<div>`, so the giscus comment thread spans the full article width instead of being capped at 48rem.
- Rename the "One command" heading in the Try Challenge modal to **Angular challenge CLI**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved documentation page layout by constraining the document content for better readability.
* **Documentation**
  * Renamed the initial “Try this challenge” setup section to “Angular challenge CLI” for clearer guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->