### PR TITLE
fix(website): make giscus comments full width

### DIFF
--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -189,6 +189,13 @@
   font-weight: 600;
 }
 
+/* --- Giscus comments ------------------------------------------------------- */
+/* The giscus script hard-codes width: 300px on the injected iframe; override. */
+.giscus,
+.giscus-frame {
+  width: 100% !important;
+}
+
 /* --- SendPulse newsletter form ------------------------------------------- */
 /* The embed script injects its own stylesheet; force it back on-brand. */
 


### PR DESCRIPTION
✅ Challenge Submission Checklist

Start your PR title with: Answer:${challenge_number}

⚠️ Important Notice

If you would like personal feedback or a detailed review, please support the project on GitHub:

- $5 — Review per PR
- $30 — Lifetime access to reviews and Q&A
- $100 — Lifetime access to reviews and Q&A + a 45-minute video call
  👉 https://github.com/sponsors/tomalaforge

You can also submit a PR without sponsorship to:

- Be listed among the answered challenges, or
- Receive a review from a community member. 🔥

---

The giscus script hard-codes `width: 300px` on the `.giscus` wrapper div and `.giscus-frame` iframe it injects into the DOM. Added two CSS overrides in `styles.css` to set `width: 100%` on both elements so the comment section spans the full content width.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Giscus comment sections now expand to the full available width instead of being limited to 300 pixels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->