### PR TITLE
fix(website): fix sponsor banner truncation on mobile

### DIFF
--- a/website/src/app/pages/landing/landing.html
+++ b/website/src/app/pages/landing/landing.html
@@ -12,8 +12,8 @@
   <div class="relative z-10 border-b border-neutral-200/60 bg-neutral-100/40 dark:border-neutral-800/60 dark:bg-neutral-900/40">
     <div
       class="mx-auto flex w-full max-w-6xl items-center justify-between gap-3 px-4 py-2.5 text-sm text-neutral-700 sm:px-6 dark:text-neutral-300">
-      <div class="flex min-w-0 items-center gap-3">
-        <span class="truncate"><span class="sm:hidden">Sustained by sponsors</span><span class="hidden sm:inline">This project is sustained by its sponsors</span></span>
+      <div class="flex items-center gap-3">
+        <span class="sm:hidden">Sponsors</span><span class="hidden sm:inline">This project is sustained by its sponsors</span>
         @if (sponsors().length > 0) {
           <span class="flex -space-x-1.5">
             @for (sponsor of sponsors(); track sponsor.login) {


### PR DESCRIPTION
## Summary

- Replace truncated "Sustained by sponsors" text with "Sponsors" on mobile to prevent text overflow
- Remove `min-w-0` and `truncate` classes that caused the ellipsis
- Desktop keeps the full "This project is sustained by its sponsors" string unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the sponsors banner to display “Sponsors” on small screens.
  * Preserved the full sponsor message on larger screens.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->